### PR TITLE
Make response argument optional.

### DIFF
--- a/Classes/Controller/XmlimportModuleController.php
+++ b/Classes/Controller/XmlimportModuleController.php
@@ -414,7 +414,7 @@ class XmlimportModuleController
      * @param ServerRequestInterface $request the current request
      * @return Response the response with the content
      */
-    public function mainAction(ServerRequestInterface $request, ResponseInterface $response)
+    public function mainAction(ServerRequestInterface $request, ResponseInterface $response = null)
     {
         $GLOBALS['SOBE'] = $this;
         $this->init();


### PR DESCRIPTION
Problem: In TYPO3 version > 8 with DI service configurations, calling XmlimportModuleController::mainAction throws an `Too few arguments to function Digicademy\Xmltool\Controller\XmlimportModuleController::mainAction(), 1 passed and exactly 2 expected` exception.

The reason is that in order to preserve downward compatibility, an instance of `ResponseInterface` can still be provided.

```
public function mainAction(ServerRequestInterface $request, ResponseInterface $response)
```

This no longer happens in later versions (the response object is instatiated from a factory now instead) and leads to fewer arguments passed to the function and an exception.

To avoid this while keeping downward compatibility, the `$response` argument can be made optional by defaulting it to null.